### PR TITLE
LIBDRS-8946 - Update base image in Dockerfile to update to Java 11.0.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY ./src ./src
 RUN mvn package -DskipTests
 
 # final base image
-FROM openjdk:11-jre-slim
+FROM registry.lts.harvard.edu/lts/lts-tomcat-base:latest
 
 ARG APP_ID_NUMBER=61
 ARG APP_ID_NAME=drsadm


### PR DESCRIPTION
**JIRA Ticket**: https://jira.huit.harvard.edu/browse/LIBDRS-8946

# What does this Pull Request do?
Updates the base image in the Dockerfile so that, when running the final image Java 11.0.16 is running.

# How should this be tested?
From a Terminal:

- Build the image `docker-compose -f docker-compose-local.yml build --no-cache`
- Run the image `docker-compose -f docker-compose-local.yml up`
- Examine the output an notice the Java version is 11.0.16

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n/a
- integration tests? n/a

# Interested parties
@cvicary 