### PR TITLE
Enable log output to console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ target/
 
 *.iml
 .idea
+.vscode/settings.json

--- a/application-local.yml
+++ b/application-local.yml
@@ -1,0 +1,57 @@
+info:
+  build:
+    artifact: "@project.artifactId@"
+    name: "@project.name@"
+    description: "@project.description@"
+    version: "@project.version@"
+
+logging:
+  charset:
+    console: UTF-8
+    file: UTF-8
+  file:
+    path: # empty for console logging | path for file logging (i.e. /logs)
+  console:
+    enabled: true # true (console logging) | false (file logging)
+  level:
+    edu.harvard.drs: DEBUG
+    org.springframework: INFO
+    web: INFO
+    root: INFO
+
+management:
+  endpoint:
+    health:
+      enabled: true
+      showDetails: always
+    info:
+      enabled: true
+    logfile:
+      enabled: false # true (file logging) | false (console logging)
+  endpoints:
+    enabled-by-default: false
+    web:
+      exposure:
+        include: health, info, logfile
+
+server:
+  port: 9000
+  servlet:
+    context-path:
+
+spring:
+  application:
+    name: DRS Verify
+  profiles:
+    active: development
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+  devtools:
+    addProperties: true
+    livereload:
+      enabled: true
+
+  main:
+    lazyInitialization: true

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -4,8 +4,10 @@ services:
   service:
     build:
       context: .
-    env_file: .env
+    environment:
+      - SPRING_CONFIG_LOCATION=/config/
     ports:
       - 9000:9000
     volumes:
       - ./logs:/logs
+      - ./application-local.yml:/config/application.yml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>edu.harvard.drs</groupId>
   <artifactId>verify</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>edu.harvard.drs:verify</name>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,11 +10,14 @@ logging:
     console: UTF-8
     file: UTF-8
   file:
-    path: logs
+    path: /logs # empty for console logging | path for file logging (i.e. /logs)
+  console:
+    enabled: false # true (console logging) | false (file logging)
   level:
     edu.harvard.drs: DEBUG
     org.springframework: INFO
     web: INFO
+    root: INFO
 
 management:
   endpoint:
@@ -24,7 +27,7 @@ management:
     info:
       enabled: true
     logfile:
-      enabled: true
+      enabled: true # true (file logging) | false (console logging)
   endpoints:
     enabled-by-default: false
     web:


### PR DESCRIPTION
**Enable log output to console.**
* * *

**JIRA Ticket**: [LTSK8S-693](https://at-harvard.atlassian.net/browse/LTSK8S-693)

# What does this Pull Request do?
`drs-verify` writes to a single log at `logs/spring.log` by default. Console logging can be enabled via configuration. This PR adds a local configuration file used for local deployments.

# How should this be tested?
- Compile jar and run tests (sanity check)
    - `mvn clean install`
- Build docker image (will rebuild jar)
    - `docker-compose -f docker-compose-local.yml build --no-cache`
- View local configuration 
    - `less application-local.yml`
        - See comments in file. Console logging enabled.
- Start container
    - `docker-compose -f docker-compose-local.yml up`
    - Wait for startup
- Verify no logging to file (in another terminal)
    - `ls logs/spring.log`
- Stop container
    - `docker-compose -f docker-compose-local.yml down`
- Edit local configuration to enable file logging
    - `vi application-local.yml`
    - See comments to enable file logging
- Start container
    - `docker-compose -f docker-compose-local.yml up`
- See logging go to file (in another terminal)
    - `tail -f logs/spring.log`
- Stop container
    - `docker-compose -f docker-compose-local.yml down`

# Test coverage
Yes/No: No

# Interested parties
@ives1227, @awoods 


[LTSK8S-693]: https://at-harvard.atlassian.net/browse/LTSK8S-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ